### PR TITLE
Move Silverlight object off-screen.

### DIFF
--- a/evercookie.js
+++ b/evercookie.js
@@ -534,7 +534,7 @@ var evercookie = (function (window) {
         '<param name="background" value="Transparent"/>' +
         '<param name="windowless" value="true"/>' +
         '<param name="minRuntimeVersion" value="' + minver + '"/>' +
-        '<param name="autoUpgrade" value="true"/>' +
+        '<param name="autoUpgrade" value="false"/>' +
         '<a href="http://go.microsoft.com/fwlink/?LinkID=149156&v=' + minver + '" style="display:none">' +
         'Get Microsoft Silverlight' +
         '</a>' +


### PR DESCRIPTION
Move Silverlight object off-screen. Hide "Install Silverlight" link - we can't remove it without triggering the Firefox "You need additional plugins to see this page" infobar. Set silverlight not to prompt the user to upgrade if it is out of date - interrupting the user is bad.
