### PR TITLE
ajax requests handle caching

### DIFF
--- a/evercookie.js
+++ b/evercookie.js
@@ -372,8 +372,11 @@
       if (value !== undefined) {
         // make sure we have evercookie session defined first
         document.cookie = opts.cacheCookieName + "=" + value + "; domain=" + _ec_domain;
-        // {{opts.cachePath}} handles caching
-        newImage(_ec_baseurl + opts.cachePath + "?name=" + name);
+        // {{ajax request to opts.cachePath}} handles caching
+        self.ajax({
+          url: _ec_baseurl + opts.cachePath + "?name=" + name,
+          success: function (data) {}
+        });
       } else {
         // interestingly enough, we want to erase our evercookie
         // http cookie so the php will force a cached response
@@ -411,8 +414,11 @@
       if (value !== undefined) {
         // make sure we have evercookie session defined first
         document.cookie = opts.etagCookieName + "=" + value + "; domain=" + _ec_domain;
-        // {{opts.etagPath}} handles etagging
-        newImage(_ec_baseurl + opts.etagPath + "?name=" + name);
+        // {{ajax request to opts.etagPath}} handles etagging
+        self.ajax({
+          url: _ec_baseurl + opts.etagPath + "?name=" + name,
+          success: function (data) {}
+        });
       } else {
         // interestingly enough, we want to erase our evercookie
         // http cookie so the php will force a cached response


### PR DESCRIPTION
It was noticed that Firefox 29 in private mode got empty strings in etag and ecache because initial caching was made through masquerading as Image object.  XmlHttpRequests fixed the problem.
