### PR TITLE
etag header needs to be resent always

### DIFF
--- a/evercookie_etag.php
+++ b/evercookie_etag.php
@@ -40,7 +40,7 @@ if (!$_COOKIE["evercookie_etag"])
 
     $headers = apache_request_headers();
     echo $headers['If-None-Match'];
-
+    header('Etag: $headers["If-None-Match"]')
 	exit;
 }
 


### PR DESCRIPTION
if client sends If-None-Match request header,  the server should set corresponding Etag in response
