### PR TITLE
Prior code buggy, ineffective.

### DIFF
--- a/php/evercookie_etag.php
+++ b/php/evercookie_etag.php
@@ -10,43 +10,14 @@
  */
 
 // we don't have a cookie, so we're not setting it
-if (!isset($_COOKIE['evercookie_etag']) || empty($_COOKIE['evercookie_etag'])) {
-    // read our etag and pass back
-    if (!function_exists('apache_request_headers')) {
-
-        function apache_request_headers()
-        {
-            // Source: http://www.php.net/manual/en/function.apache-request-headers.php#70810
-            $arh = array();
-            $rx_http = '/\AHTTP_/';
-            foreach ($_SERVER as $key => $val) {
-                if (preg_match($rx_http, $key)) {
-                    $arh_key = preg_replace($rx_http, '', $key);
-                    $rx_matches = array();
-                    // do some nasty string manipulations to restore the original letter case
-                    // this should work in most cases
-                    $rx_matches = explode('_', $arh_key);
-                    if (count($rx_matches) > 0 and strlen($arh_key) > 2) {
-                        foreach ($rx_matches as $ak_key => $ak_val) {
-                            $rx_matches[$ak_key] = ucfirst($ak_val);
-                        }
-                        $arh_key = implode('-', $rx_matches);
-                    }
-                    $arh[$arh_key] = $val;
-                }
-            }
-
-            return ($arh);
-        }
-    }
-
-    $headers = apache_request_headers();
-    echo $headers['If-None-Match'];
-
-    header('Etag: $headers["If-None-Match"]')
-		exit;
+if (empty($_COOKIE['evercookie_etag'])) {
+    header("HTTP/1.1 304 Not Modified");
+    header("If-None-Match: *");
+    exit;
 }
 
 // set our etag
+header("HTTP/1.1 200 OK");
 header('Etag: ' . $_COOKIE['evercookie_etag']);
 echo $_COOKIE['evercookie_etag'];
+exit;


### PR DESCRIPTION
Echoing output before headers, this (from original source) is more simple and works. If the cookie does not exist, respond with 304 Not Modified (ie: cached, evercookie.js: line #446 )
