### PR TITLE
Hotfix header case insensitive comparison

### DIFF
--- a/php/evercookie_etag.php
+++ b/php/evercookie_etag.php
@@ -46,7 +46,7 @@ if (empty($_COOKIE[$cookie_name])) {
     $headers = array_change_key_case(apache_request_headers(), CASE_UPPER);
     if(isset($headers['IF-NONE-MATCH'])) {
         // extracting value from ETag presented format (which may be prepended by Weak validator modifier)
-        $etag_value = preg_replace('|^(W/)?"(.+)"$|', '$2', $headers['If-None-Match']);
+        $etag_value = preg_replace('|^(W/)?"(.+)"$|', '$2', $headers['IF-NONE-MATCH']);
         header('HTTP/1.1 304 Not Modified');
         header('ETag: "' . $etag_value . '"');
         echo $etag_value;


### PR DESCRIPTION
After modifying the code to change header keys to all uppercase, preg_replace was left out, so it was still using the lowercase key to compare with the header.